### PR TITLE
Include: mx6qmf0300_common: fix 8.0 Oreo u-boot args

### DIFF
--- a/include/configs/mx6qmf0300_common.h
+++ b/include/configs/mx6qmf0300_common.h
@@ -142,7 +142,7 @@
     "sdcard_args=setenv bootargs console=" CONFIG_CONSOLE_DEV "," __stringify(CONFIG_BAUDRATE) " " \
         "rdinit=/sdcard.flasher.rc " \
         "enable_wait_mode=off "\
-        "video=mxcfb0:dev=ldb,bpp=32 " \
+        "video=mxcfb0:dev=ldb,fbpix=RGB32,bpp=32 " \
         "consoleblank=0 " \
         "androidboot.hardware=freescale " \
         "cma=384M " \
@@ -160,13 +160,14 @@
         "init=/init " \
         "rootfstype=ext4 " \
         "enable_wait_mode=off "\
-        "video=mxcfb0:dev=ldb,bpp=32 " \
-        "video=mxcfb1:dev=hdmi,if=RGB24,bpp=32 " \
-        "vmalloc=400M " \
+        "video=mxcfb0:dev=ldb,fbpix=RGB32,bpp=32 " \
+        "video=mxcfb1:off video=mxcfb2:off video=mxcfb3:off " \
+        "vmalloc=128M " \
         "androidboot.console=" CONFIG_CONSOLE_DEV " " \
         "consoleblank=0 " \
         "androidboot.hardware=freescale " \
-        "cma=384M " \
+        "cma=448M " \
+        "galcore.contiguousSize=33554432 " \
         "\0" \
     "bootcmd_android=run android_args;" \
         "boota mmc${internal_mmc_dev};\0" \
@@ -178,14 +179,15 @@
         "init=/init " \
         "rootfstype=ext4 " \
         "enable_wait_mode=off "\
-        "video=mxcfb0:dev=ldb,bpp=32 " \
-        "video=mxcfb1:dev=hdmi,if=RGB24,bpp=32 " \
-        "vmalloc=400M " \
+        "video=mxcfb0:dev=ldb,fbpix=RGB32,bpp=32 " \
+        "video=mxcfb1:off video=mxcfb2:off video=mxcfb3:off " \
+        "vmalloc=128M " \
         "androidboot.console=" CONFIG_CONSOLE_DEV " " \
         "consoleblank=0 " \
         "androidboot.hardware=freescale " \
         "androidboot.selinux=permissive " \
-        "cma=384M " \
+        "cma=448M " \
+        "galcore.contiguousSize=33554432 " \
         "\0" \
     "bootcmd_android_permissive=run android_permissive_args;" \
         "boota mmc${internal_mmc_dev};\0"


### PR DESCRIPTION
Because u-boot codebase are completely copied from u-boot for android 6.0
and we have no time before release, we can just put the crutch now:
replace android 6.0 kernel arguments with android 8.0 arguments.